### PR TITLE
Fix JS error on Linux

### DIFF
--- a/src/stores/device.js
+++ b/src/stores/device.js
@@ -59,7 +59,9 @@ function check1015() {
     const os = Bowser.getParser(window.navigator.userAgent).getOS();
     const isMac = os.name === "macOS";
     
-    // We only care about os.version if the user is on Mac OS X,
+    // We only care about os.version if the user is on Mac OS X
+    if (!isMac) return false;
+    
     // The following approach works only on Mac OSX because their os.version is always in the format 'xx.xx.xx'
     // If OS version is a whole number with no decimal, do not split but instead make minor == 0
     const version = {


### PR DESCRIPTION
Hey :wave: 

I'm using Chrome on Linux and got this error while trying to read an article:

![image](https://user-images.githubusercontent.com/4437/148858303-887d8d1b-9e07-42bc-84b4-1d44944c71f2.png)

I think it's because `os.version.split()` is returning `null`. 